### PR TITLE
reference views for data instead of raw tables to limit display data

### DIFF
--- a/chyf-web/src/main/java/net/refractions/chyf/model/DataSourceTable.java
+++ b/chyf-web/src/main/java/net/refractions/chyf/model/DataSourceTable.java
@@ -25,13 +25,16 @@ public enum DataSourceTable {
 	VECTOR_TILE_CACHE("chyf2.vector_tile_cache"),
 	WORK_UNIT("chyf2.nhn_workunit"),
 	AOI("chyf2.aoi"),
-	EFLOWPATH("chyf2.eflowpath"), 
 	EFLOWPATH_ATTRIBUTES("chyf2.eflowpath_attributes"),
-	ECATCHMENT("chyf2.ecatchment"),
 	ECATCHMENT_ATTRIBUTES("chyf2.ecatchment_attributes"),
 	NAMES("chyf2.names"),
-	SHORELINE("chyf2.shoreline"),
-	NEXUS("chyf2.nexus"),
+	//use view for data tables
+	//view filters out only the aoi's flagged 
+	//for display in the aoi table
+	SHORELINE("chyf2.shoreline_vw"),
+	NEXUS("chyf2.nexus_vw"),
+	EFLOWPATH("chyf2.eflowpath_vw"),
+	ECATCHMENT("chyf2.ecatchment_vw"),
 	
 	EC_TYPE("chyf2.ec_type_codes"),
 	EC_SUBTYPE("chyf2.ec_subtype_codes"),


### PR DESCRIPTION
we wanted to ask you what it would take set up a flag on the chyf2 schema AOI table, like what you did with the AOI table for processing, that would allow us to decide which networks we want/don't want displayed in the app at any given time.