### PR TITLE
remove extra fields from nhnworkunit tiles

### DIFF
--- a/chyf-web/src/main/java/net/refractions/chyf/model/dao/VectorTileDao.java
+++ b/chyf-web/src/main/java/net/refractions/chyf/model/dao/VectorTileDao.java
@@ -107,8 +107,7 @@ public class VectorTileDao {
 			}
 			sb.append(" , " + srid );
 			sb.append("), bounds.b2d) AS geom, ");
-			sb.append(" id, name_en, name_fr, ");
-			sb.append(" major_drainage_area_en as major_drainage_area, sub_drainage_area_en as sub_drainage_area, sub_sub_drainage_area_en as sub_sub_drainage_area");
+			sb.append(" id, name_en, name_fr ");
 			sb.append("	FROM ");
 			sb.append(DataSourceTable.WORK_UNIT.tableName);
 			sb.append(" t, bounds ");


### PR DESCRIPTION
followup to other en/fr translations of work unit names in tiles - removing extra fields so only name_en and name_fr are included to keep size to a minimum